### PR TITLE
Adjust example with newest code

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,6 +1,6 @@
 {
   "directory" : "public/vendor",
   "scripts": {
-    "postinstall": "bower-requirejs -t -c public/config.js"
+    "postinstall": "./node_modules/.bin/bower-requirejs -t -c public/config.js"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # jsroot-example
 
-This is simple example how JSROOT can be installed and used from bower
+This is simple example how JSROOT can be installed and used from Node.js and bower
 
-In simple case just do:
+To run example, checkout repository and call:
 
-   bower install jsroot
+    [shell] npm start
+
+It should start HTTP server at port 3000.
+
+There is three html pages, showing usage of JSROOT:
+
+
+
+index.html shows how to use JSROOT.
+
+    <script src="vendor/jsroot/scripts/JSRootCore.js?bower" type="text/javascript"></script>
+
+Here one specifies addditional URL parameter '?bower', which  says JSROOT to reuses scripts like d3.js or three.js from bower installation.
+
+
+
+index_require_intern.html shows method to include JSRootCore.js with require.js. 
+It is standard method, which uses internal libraries from JSROOT directories.
+
+
+
+index_require_extern.html uses package configuration info, which is automatically created when
+example repository checked out. There is '.bowerrc' file, which contains post-install command
+   "postinstall": "./node_modules/.bin/bower-requirejs -t -c public/config.js"
+   
+File config.js included into HTML pages and let JSROOT directly reuse bower packages
+
+
+To install only JSROOT with bower do:
+
+   [shell] bower install jsroot
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # jsroot-example
+
+This is simple example how JSROOT can be installed and used from bower
+
+In simple case just do:
+
+   bower install jsroot
+
+

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,8 @@
     <!--script src="vendor/threejs/build/three.min.js"></script-->
     <!--script src="main.js"></script-->
 
-    <script src="vendor/jsroot/scripts/JSRootCore.js" type="text/javascript"></script>
+   <!-- here ?bower flag indicates that we are working with bower installed scripts, JSROOT will use libraries from bower -->
+    <script src="vendor/jsroot/scripts/JSRootCore.js?bower" type="text/javascript"></script>
 
     <script type='text/javascript'>
         // json file stored in same folder, absolute address can be used as well

--- a/public/index_require_extern.html
+++ b/public/index_require_extern.html
@@ -16,6 +16,7 @@
 
     <script src="main.js"></script>
     <script type='text/javascript'>
+        // load jsroot, defined in config.js. All external like d3 or jquery will be used from bower installation
         require(['jsroot'], function(jsroot) {
            jsroot.NewHttpRequest("hpx.json", 'object', function(obj) {
                jsroot.draw("drawing", obj, "hist");

--- a/public/index_require_intern.html
+++ b/public/index_require_intern.html
@@ -15,9 +15,8 @@
 
     <script src="main.js"></script>
     <script type='text/javascript'>
-        requirejs.config({ paths: { "jsroot" : "vendor/jsroot/scripts/JSRootCore" } });
-
-        require(["jsroot"], function(jsroot) {
+        // show how to load JSROOT with require.js, it will reuse internal JSROOT libraries
+        require(["vendor/jsroot/scripts/JSRootCore"], function(jsroot) {
            jsroot.NewHttpRequest("hpx.json", 'object', function(obj) {
                jsroot.draw("drawing", obj, "hist");
            }).send();


### PR DESCRIPTION
Now in default case one can reuse bower-installed scripts.
Just write JSRootCore.js?bower in URL string.
Also problem with require.js is clarified.
